### PR TITLE
"in any case": Effortless contributions

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,6 +1,7 @@
 <?php 
 class DbConfig {
   const HOST = 'localhost';
+  const PORT = 3306;
   const DBNAME = 'test_database'; 
   const USER = 'root';
   const PASSWORD = 'password';

--- a/dumbledorm.php
+++ b/dumbledorm.php
@@ -141,7 +141,7 @@ abstract class Db {
    */
   public static function pdo() {
     if (!self::$_pdo) {
-      self::$_pdo = new PDO('mysql:host='.DbConfig::HOST.';dbname='.DbConfig::DBNAME, DbConfig::USER, DbConfig::PASSWORD);
+      self::$_pdo = new PDO('mysql:host='.DbConfig::HOST.';port='.DbConfig::PORT.';dbname='.DbConfig::DBNAME, DbConfig::USER, DbConfig::PASSWORD);
       self::$_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     }
     return self::$_pdo;

--- a/generate.php
+++ b/generate.php
@@ -1,0 +1,28 @@
+#!/usr/bin/php
+<?php
+if (in_array($argv[1], array('--help', '-help', '-h', '-?'))) {
+?>
+
+Generate DumbledORM models.
+
+  Usage:
+  <?php echo $argv[0]; ?> <option>
+
+  <option> 
+      -h, -?, --help, -help            Print this help message
+      -p, --prefix <prefix>            Prefix generated classes
+      -d, --dir <directory>            Output directory for the model instead of the default ./model 
+
+<?php
+} else {
+$params = array(
+  'p:' => 'prefix:',
+  'd:' => 'dir:',
+);
+$opt = getopt(implode('', array_keys($params)), $params);
+
+require('config.php');
+require('dumbledorm.php');
+Builder::generateBase($opt['p'], ($opt['d'] ? $opt['d'] : 'model'));
+}
+?>


### PR DESCRIPTION
Thank you for this, can we call it a library? I have one word, **Wow**!
Never could understand why ORM has to be overcomplicated especially not in a type free language such as PHP. Well done!

My small contribution to this wonderful piece of work:
- I also required the custom mysql server port as per the request by [jiminoc](/jiminoc) in issue #1 so had to do this nickl-/DumbledORM@26182f4d "in any case"
- Since I had to run the model generation from the command line "in any case" I had to put the routines in a CLI script "in any case" so I prettied it up a bit and it now conforms to the whole specification.

If you run `./generate.php -h` the usage will be explained as:

```
Generate DumbledORM models.

  Usage:
  ./generate.php <option>

  <option>
      -h, -?, --help, -help            Print this help message
      -p, --prefix <prefix>            Prefix generated classes
      -d, --dir <directory>            Output directory for the model instead of the default ./model

```

"In any case", thought I might as well share it so that no one else has to do it again "in any case".

If you came up with this over night I can't wait to see what you've done to it in a year! **_\_poke**** =)

Keep up the good work...
